### PR TITLE
Add blocking runtime from upstream quickwit-oss

### DIFF
--- a/.github/CI.yml
+++ b/.github/CI.yml
@@ -1,0 +1,60 @@
+
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - uses: Swatinem/rust-cache@v1
+
+  lints:
+    name: Lints & Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - uses: Swatinem/rust-cache@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,8 @@ dependencies = [
  "flume",
  "futures",
  "http",
+ "num_cpus",
+ "once_cell",
  "prometheus",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,41 +1,43 @@
 [package]
-    name          = "witty-actors"
-    version       = "0.6.0"
-    authors       = ["Quickwit, Inc. <hello@quickwit.io>"]
-    edition       = "2021"
-    license       = "MIT"
-    description   = "Fork of quickwit-actors, Actor framework used in quickwit"
-    repository    = "https://github.com/valyagolev/witty-actors"
-    homepage      = "https://docs.rs/witty-actors"
-    documentation = "https://docs.rs/witty-actors"
+name = "witty-actors"
+version = "0.6.0"
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2021"
+license = "MIT"
+description = "Fork of quickwit-actors, Actor framework used in quickwit"
+repository = "https://github.com/valyagolev/witty-actors"
+homepage = "https://docs.rs/witty-actors"
+documentation = "https://docs.rs/witty-actors"
 
 [dependencies]
-    anyhow      = "1"
-    async-trait = "0.1"
-    flume       = "0.10"
-    futures     = "0.3"
-    http        = "0.2"
-    prometheus  = "0.13"
-    rand        = "0.8"
-    serde       = { version = "1.0", features = ["derive"] }
-    serde_json  = "1"
-    thiserror   = "1"
-    tokio       = { version = "1.29", features = ["sync", "rt", "time", "macros"] }
-    tracing     = "0.1"
+anyhow = "1"
+async-trait = "0.1"
+flume = "0.10"
+futures = "0.3"
+http = "0.2"
+prometheus = "0.13"
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1.29", features = ["sync", "rt", "time", "macros", "rt-multi-thread"] }
+tracing = "0.1"
+once_cell = "1.18.0"
+num_cpus = "1.16.0"
 
 [dev-dependencies]
-    criterion = { version = "0.5.1", features = ["async_tokio"] }
-    tokio = { version = "1.29", features = [
-        "sync",
-        "rt",
-        "time",
-        "macros",
-        "rt-multi-thread",
-    ] }
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+tokio = { version = "1.29", features = [
+    "sync",
+    "rt",
+    "time",
+    "macros",
+    "rt-multi-thread",
+] }
 
 [features]
-    testsuite = []
+testsuite = []
 
 [[bench]]
-    name    = "bench"
-    harness = false
+name = "bench"
+harness = false

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The API may change in the future.
 # Features
 
 - Actor message box
-- The framework is meant to run asynchronous actors by default, but it can also run actors that are blocking for long amount of time. The message handler methods are technically asynchronous in both case, but the `Actor::runner` method makes it possible to run an actor with blocking code on a dedicated thread.
+- The framework is meant to run asynchronous actors by default, but it can also run actors that are blocking for long amount of time. The message handler methods are technically asynchronous in both case, but the `RuntimeType::get_runtime_handle` method makes it possible to run an actor with blocking code on a dedicated thread.
 - A scheduler actor that makes it possible to mock simulate time.
 
 # Example

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -122,7 +122,7 @@ pub trait Actor: Send + Sync + Sized + 'static {
     /// of execution of the Actor.
     ///
     /// Actor with a handler that may block for more than 50 microseconds
-    /// should use the `ActorRunner::DedicatedThread`.
+    /// should use the [`RuntimeType::get_runtime_handle`].
     fn runtime_handle(&self) -> tokio::runtime::Handle {
         tokio::runtime::Handle::current()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub(crate) mod scheduler;
 mod spawn_builder;
 mod supervisor;
 
+mod runtime;
+
 pub use scheduler::{start_scheduler, SchedulerClient};
 
 #[cfg(test)]
@@ -68,6 +70,7 @@ pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError, TrySe
 pub use self::mailbox::{Inbox, Mailbox};
 pub use self::registry::ActorObservation;
 pub use self::supervisor::{Supervisor, SupervisorState};
+pub use runtime::{RuntimeType, RuntimesConfig};
 
 /// Heartbeat used to verify that actors are progressing.
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,151 @@
+// Copyright (C) 2023 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static RUNTIMES: OnceCell<HashMap<RuntimeType, tokio::runtime::Runtime>> = OnceCell::new();
+
+/// Describes which runtime an actor should run on.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum RuntimeType {
+    /// The blocking runtime runs blocking actors.
+    /// This runtime is only used as a nice thread pool with
+    /// the interface as tokio stasks.
+    ///
+    /// This runtime should not be used to run tokio
+    /// io operations.
+    ///
+    /// Tasks are allowed to block for an arbitrary amount of time.
+    Blocking,
+
+    /// The non-blocking runtime is closer to what one would expect from
+    /// a regular tokio runtime.
+    ///
+    /// Task are expect to yield within 500 micros.
+    NonBlocking,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimesConfig {
+    /// Number of worker threads allocated to the non-blocking runtime.
+    pub num_threads_non_blocking: usize,
+    /// Number of worker threads allocated to the blocking runtime.
+    pub num_threads_blocking: usize,
+}
+
+impl RuntimesConfig {
+    pub fn with_num_cpus(num_cpus: usize) -> Self {
+        // Non blocking task are supposed to be io intensive, and  not require many threads...
+        let num_threads_non_blocking = if num_cpus > 6 { 2 } else { 1 };
+        // On the other hand the blocking actors are cpu intensive. We allocate
+        // almost all of the threads to them.
+        let num_threads_blocking = (num_cpus - num_threads_non_blocking).max(1);
+        RuntimesConfig {
+            num_threads_non_blocking,
+            num_threads_blocking,
+        }
+    }
+}
+
+impl Default for RuntimesConfig {
+    #[cfg(not(any(test, feature = "testsuite")))]
+    fn default() -> Self {
+        let num_cpus = num_cpus::get();
+        Self::with_num_cpus(num_cpus)
+    }
+
+    #[cfg(any(test, feature = "testsuite"))]
+    fn default() -> Self {
+        Self {
+            num_threads_blocking: 1,
+            num_threads_non_blocking: 1,
+        }
+    }
+}
+
+fn start_runtimes(config: RuntimesConfig) -> HashMap<RuntimeType, tokio::runtime::Runtime> {
+    let mut runtimes = HashMap::default();
+    let blocking_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(config.num_threads_blocking)
+        .thread_name_fn(|| {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::AcqRel);
+            format!("blocking-{id}")
+        })
+        .enable_all()
+        .build()
+        .unwrap();
+    runtimes.insert(RuntimeType::Blocking, blocking_runtime);
+    let non_blocking_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(config.num_threads_non_blocking)
+        .thread_name_fn(|| {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::AcqRel);
+            format!("non-blocking-{id}")
+        })
+        .enable_all()
+        .build()
+        .unwrap();
+    runtimes.insert(RuntimeType::NonBlocking, non_blocking_runtime);
+    runtimes
+}
+
+impl RuntimeType {
+    pub fn get_runtime_handle(self) -> tokio::runtime::Handle {
+        RUNTIMES
+            .get_or_init(|| {
+                #[cfg(any(test, feature = "testsuite"))]
+                tracing::warn!("Starting Tokio actor runtimes for tests.");
+
+                start_runtimes(RuntimesConfig::default())
+            })
+            .get(&self)
+            .unwrap()
+            .handle()
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtimes_config_default() {
+        let runtime_default = RuntimesConfig::default();
+        assert!(runtime_default.num_threads_non_blocking <= runtime_default.num_threads_blocking);
+        assert!(runtime_default.num_threads_non_blocking <= 2);
+    }
+
+    #[test]
+    fn test_runtimes_with_given_num_cpus_10() {
+        let runtime = RuntimesConfig::with_num_cpus(10);
+        assert_eq!(runtime.num_threads_blocking, 8);
+        assert_eq!(runtime.num_threads_non_blocking, 2);
+    }
+
+    #[test]
+    fn test_runtimes_with_given_num_cpus_3() {
+        let runtime = RuntimesConfig::with_num_cpus(3);
+        assert_eq!(runtime.num_threads_blocking, 2);
+        assert_eq!(runtime.num_threads_non_blocking, 1);
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -271,9 +271,13 @@ impl Scheduler {
 
     /// Schedules a Timeout event callback if necessary.
     fn schedule_next_timeout(&mut self) {
-        let Some(scheduler_client) = self.scheduler_client() else { return };
+        let Some(scheduler_client) = self.scheduler_client() else {
+            return;
+        };
         let simulated_now = self.simulated_now();
-        let Some(next_deadline) = self.next_event_deadline() else { return; };
+        let Some(next_deadline) = self.next_event_deadline() else {
+            return;
+        };
         let timeout: Duration = if next_deadline <= simulated_now {
             // This should almost never happen, because we supposedly triggered
             // all pending events.
@@ -320,14 +324,18 @@ impl Scheduler {
     /// - no message is queued for processing, no initialize or no finalize
     /// is being processed.
     fn advance_time_if_necessary(&mut self) {
-        let Some(scheduler_client) = self.scheduler_client() else { return; };
+        let Some(scheduler_client) = self.scheduler_client() else {
+            return;
+        };
         if !scheduler_client.time_is_accelerated() {
             return;
         }
         if scheduler_client.is_advance_time_forbidden() {
             return;
         }
-        let Some(advance_to_instant) = self.next_event_deadline() else { return; };
+        let Some(advance_to_instant) = self.next_event_deadline() else {
+            return;
+        };
         let now = self.simulated_now();
         if let Some(time_shift) = advance_to_instant.checked_duration_since(now) {
             self.simulated_time_shift += time_shift;


### PR DESCRIPTION
This PR add the ability to select a blocking runtime via `Actor::runtime_handle` as implemented in https://github.com/quickwit-oss/quickwit/blob/926c0f7650b2369c44922ddb6d387aa194b42aee/quickwit/quickwit-common/src/runtimes.rs#L112

I made a little change to the original implementation to simplify feature selection (between test runtime and non test runtime). 

Also I am not sure but I think this should be `spawn_blocking` when `RuntimeType::Blocking` is used.  
https://github.com/guilload/witty-actors/blob/25b3df45848b2e6670a2ce874bee6c8a2a8e93ef/src/spawn_builder.rs#L167 

Either I am missing something or using ``RunType::TypeBlocking` does nothing except controlling the number of worker_thread on the tokio runtime.

Can you clarify on this ? 